### PR TITLE
[2021-04-05]용석:테스트 구동에 필요한 DB 및 JPA 환경 설정

### DIFF
--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,24 @@
+spring:
+  # [Datasource]
+  datasource:
+    url: jdbc:h2:mem:test_db
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+
+  # [h2]
+  h2:
+    console:
+      enabled: true # H2 Database Console 접속 여부 설정
+      path: /h2-console # H2 Database Console 접속 URL 설정 : localhost:8080/h2-console
+
+  # [JPA]
+  jpa:
+    hibernate:
+      ddl-auto: create-drop # create auto ddl script 옵션 create-drop : application 기동 시점에 Entity를 기준으로 Table Create 후 Application 종료 시점에 Drop
+
+# [p6spy]
+decorator:
+  datasource:
+    p6spy:
+      enable-logging: true # 실행 쿼리 출력 시 파라미터가 바인딩된 실행 쿼리 출력을 위한 옵션


### PR DESCRIPTION
 - Datasource : Test Database로 사용할 InMemory H2 설정
 - JPA : create auto ddl script 옵션 'create-drop' 설정
   -  create-drop : application 기동 시점에 Entity를 기준으로 Table Create 후 Application 종료 시점에 Drop
 - p6spy : 실행 쿼리 출력 시 파라미터가 바인딩된 실행 쿼리 출력을 위한 옵션 설정