### PR TITLE
[2021-04-05]용석:JPA와 Spring Data JPA를 이용한 Member CRUD Repository 생성 및 구현

### DIFF
--- a/src/main/java/io/example/springdatajpa/repository/MemberCrudRepositoryJpa.java
+++ b/src/main/java/io/example/springdatajpa/repository/MemberCrudRepositoryJpa.java
@@ -1,0 +1,54 @@
+package io.example.springdatajpa.repository;
+
+import io.example.springdatajpa.domain.entity.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * @author : choi-ys
+ * @date : 2021/04/05 10:55 오전
+ * @Content : JPA를 이용한 Member Entity와 DB연동 처리 Repository
+ */
+@Repository
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class MemberCrudRepositoryJpa {
+
+    private final EntityManager entityManager;
+
+    public Member save(Member member){
+        this.entityManager.persist(member);
+        return member;
+    }
+
+    public void delete(Member member){
+        this.entityManager.remove(member);
+    }
+
+    public Optional<Member> findById(long memberNo){
+        Member member = this.entityManager.find(Member.class, memberNo);
+        return Optional.ofNullable(member);
+    }
+
+    public long count() {
+        return entityManager.createQuery("select count(m) from Member as m", Long.class)
+                .getSingleResult();
+    }
+
+    /**
+     * JPQL(객체지향쿼리)을 이용한 Member Entity 목록 조회
+     *  - JPQL을 이용하여 개발자는 객체를 중심으로 Query,
+     *   실행 시점에 JPA는 JPQL에 명시된 객체를 기반으로 SQL을 생성 및 수행하여 결과를 반환
+     *  - 주의 : JPQL 실행 시점에 flush가 발생하여 쓰기 지연 저장소에 저장된 SQL이 실행 된다.
+     * @return
+     */
+    public List<Member> findAll(){
+        return entityManager.createQuery("select m from Member as m", Member.class)
+                .getResultList();
+    }
+}

--- a/src/main/java/io/example/springdatajpa/repository/MemberCrudRepositorySpringDataJpa.java
+++ b/src/main/java/io/example/springdatajpa/repository/MemberCrudRepositorySpringDataJpa.java
@@ -1,0 +1,12 @@
+package io.example.springdatajpa.repository;
+
+import io.example.springdatajpa.domain.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * @author : choi-ys
+ * @date : 2021/04/05 10:55 오전
+ * @Content : Spring Data JPA를 이용한 Member Entity와 DB연동 처리 Repository
+ */
+public interface MemberCrudRepositorySpringDataJpa extends JpaRepository<Member, Long> {
+}

--- a/src/test/java/io/example/springdatajpa/SpringDataJpaApplicationTests.java
+++ b/src/test/java/io/example/springdatajpa/SpringDataJpaApplicationTests.java
@@ -1,11 +1,13 @@
 package io.example.springdatajpa;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Profile;
 
 @SpringBootTest
 @Profile("test")
+@Disabled
 class SpringDataJpaApplicationTests {
 
     @Test

--- a/src/test/java/io/example/springdatajpa/common/BaseTest.java
+++ b/src/test/java/io/example/springdatajpa/common/BaseTest.java
@@ -1,0 +1,18 @@
+package io.example.springdatajpa.common;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Profile;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
+/**
+ * @author : choi-ys
+ * @date : 2021/04/05 1:29 오후
+ * @Content : 각 TC에서 공통으로 선언되는 Annotation 설정
+ */
+@SpringBootTest(webEnvironment = RANDOM_PORT)
+@Transactional
+@Profile("test")
+public class BaseTest {
+}

--- a/src/test/java/io/example/springdatajpa/generator/MemberGenerator.java
+++ b/src/test/java/io/example/springdatajpa/generator/MemberGenerator.java
@@ -1,0 +1,28 @@
+package io.example.springdatajpa.generator;
+
+import io.example.springdatajpa.domain.entity.Member;
+
+/**
+ * @author : choi-ys
+ * @date : 2021/04/05 11:58 오전
+ * @Content : 회원 Test case 수행에 필요한 Member Entity 생성
+ */
+public class MemberGenerator {
+
+    public static Member createMember(){
+        String memberName = "최용석";
+        int age = 31;
+        return memberBuilder(memberName, age);
+    }
+
+    public static Member createMemberByMemberName(String memberName, int age){
+        return memberBuilder(memberName, age);
+    }
+
+    private static Member memberBuilder(String memberName, int age){
+        return Member.builder()
+                .name(memberName)
+                .age(age)
+                .build();
+    }
+}

--- a/src/test/java/io/example/springdatajpa/repository/MemberCrudRepositoryJpaTest.java
+++ b/src/test/java/io/example/springdatajpa/repository/MemberCrudRepositoryJpaTest.java
@@ -1,0 +1,138 @@
+package io.example.springdatajpa.repository;
+
+import io.example.springdatajpa.common.BaseTest;
+import io.example.springdatajpa.domain.entity.Member;
+import io.example.springdatajpa.generator.MemberGenerator;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.annotation.Rollback;
+
+import javax.annotation.Resource;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * @author : choi-ys
+ * @date : 2021/04/05 11:09 오전
+ * @Content : 순수 JPA Repository Test Case
+ */
+@DisplayName("CrudRepository[JPA]:Member")
+class MemberCrudRepositoryJpaTest extends BaseTest {
+
+    @Resource
+    MemberCrudRepositoryJpa memberCrudRepositoryJpa;
+
+    @Test
+    @DisplayName("Save")
+//    @Rollback(value = false)
+    public void saveMember(){
+        // Given
+        Member member = MemberGenerator.createMember();
+
+        // When
+        Member savedMember = this.memberCrudRepositoryJpa.save(member);
+
+        // Then
+        assertEquals(savedMember, member);
+        assertEquals(savedMember.getNo(), member.getNo());
+        assertEquals(savedMember.getName(), member.getName());
+    }
+
+    @Test
+    @DisplayName("FindById")
+//    @Rollback(value = false)
+    public void findMemberById(){
+        // Given
+        Member member = MemberGenerator.createMember();
+        this.memberCrudRepositoryJpa.save(member);
+
+        // When
+        Optional<Member> optionalMember = memberCrudRepositoryJpa.findById(member.getNo());
+        Member selectedMember = optionalMember.orElseThrow();
+
+        // Then
+        assertEquals(selectedMember, member);
+    }
+
+    @Test
+    @DisplayName("Update")
+//    @Rollback(value = false)
+    public void updateMember(){
+        // Given
+        Member member = MemberGenerator.createMember();
+        Member savedMember = this.memberCrudRepositoryJpa.save(member);
+
+        // When
+        String changedMemberName = "최용";
+        member.changeMemberName(changedMemberName);
+
+        // Then
+        assertEquals(savedMember, member);
+        assertEquals(member.getName(), changedMemberName);
+    }
+
+    @Test
+    @DisplayName("Delete")
+//    @Rollback(value = false)
+    public void deleteMember(){
+        // Given
+        Member member = MemberGenerator.createMember();
+        Member savedMember = this.memberCrudRepositoryJpa.save(member);
+        assertEquals(savedMember, member);
+
+        // When
+        this.memberCrudRepositoryJpa.delete(member);
+
+        // Then
+        NoSuchElementException noSuchElementException = assertThrows(NoSuchElementException.class, () -> {
+            this.memberCrudRepositoryJpa.findById(member.getNo()).orElseThrow();
+        });
+        assertEquals(noSuchElementException.getMessage(), "No value present");
+    }
+
+    @Test
+    @DisplayName("Count")
+//    @Rollback(value = false)
+    public void memberCount(){
+        // Given
+        Member firstMember = MemberGenerator.createMemberByMemberName("최용석", 31);
+        Member secondMember = MemberGenerator.createMemberByMemberName("이성욱", 31);
+        Member thirdMember = MemberGenerator.createMemberByMemberName("박재현", 29);
+        this.memberCrudRepositoryJpa.save(firstMember);
+        this.memberCrudRepositoryJpa.save(secondMember);
+        this.memberCrudRepositoryJpa.save(thirdMember);
+
+        // When
+        long memberCount = this.memberCrudRepositoryJpa.count();
+
+        // Then
+        assertThat(memberCount).isNotZero();
+        assertEquals(memberCount, 3);
+    }
+
+    @Test
+    @DisplayName("FindAll")
+    public void findAllMember(){
+        // Given
+        Member firstMember = MemberGenerator.createMemberByMemberName("최용석", 31);
+        Member secondMember = MemberGenerator.createMemberByMemberName("이성욱", 31);
+        Member thirdMember = MemberGenerator.createMemberByMemberName("박재현", 29);
+        this.memberCrudRepositoryJpa.save(firstMember);
+        this.memberCrudRepositoryJpa.save(secondMember);
+        this.memberCrudRepositoryJpa.save(thirdMember);
+
+        // When
+        List<Member> savedMemberList = this.memberCrudRepositoryJpa.findAll();
+
+        // Then
+        assertThat(savedMemberList.size()).isNotZero();
+        assertThat(savedMemberList.contains(firstMember));
+        assertThat(savedMemberList.contains(secondMember));
+        assertThat(savedMemberList.contains(thirdMember));
+    }
+}

--- a/src/test/java/io/example/springdatajpa/repository/MemberCrudRepositorySpringDataJpaTest.java
+++ b/src/test/java/io/example/springdatajpa/repository/MemberCrudRepositorySpringDataJpaTest.java
@@ -1,0 +1,140 @@
+package io.example.springdatajpa.repository;
+
+import io.example.springdatajpa.common.BaseTest;
+import io.example.springdatajpa.domain.entity.Member;
+import io.example.springdatajpa.generator.MemberGenerator;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.annotation.Rollback;
+
+import javax.annotation.Resource;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * @author : choi-ys
+ * @date : 2021/04/05 10:58 오전
+ * @Content : Spring Data Jpa Repository Test
+ */
+@DisplayName("CrudRepository[SpringDataJpa]:Member")
+class MemberCrudRepositorySpringDataJpaTest extends BaseTest {
+
+    @Resource
+    MemberCrudRepositorySpringDataJpa memberCrudRepositorySpringDataJpa;
+
+    @Test
+    @DisplayName("Save")
+//    @Rollback(value = false)
+    public void saveMember(){
+        // Given
+        Member member = MemberGenerator.createMember();
+
+        // When
+        Member savedMember = this.memberCrudRepositorySpringDataJpa.save(member);
+
+        // Then
+        assertEquals(savedMember, member);
+        assertEquals(savedMember.getNo(), member.getNo());
+        assertEquals(savedMember.getName(), member.getName());
+    }
+
+    @Test
+    @DisplayName("FindById")
+//    @Rollback(value = false)
+    public void findMemberById(){
+        // Given
+        Member member = MemberGenerator.createMember();
+        this.memberCrudRepositorySpringDataJpa.save(member);
+
+        // When
+        Optional<Member> optionalMember = this.memberCrudRepositorySpringDataJpa.findById(member.getNo());
+        Member selectedMember = optionalMember.orElseThrow();
+
+        // Then
+        assertEquals(selectedMember, member);
+    }
+
+    @Test
+    @DisplayName("Update")
+//    @Rollback(value = false)
+    public void updateMember(){
+        // Given
+        Member member = MemberGenerator.createMember();
+        Member savedMember = this.memberCrudRepositorySpringDataJpa.save(member);
+
+        // When
+        String changedMemberName = "최용";
+        member.changeMemberName(changedMemberName);
+
+        // Then
+        assertEquals(savedMember, member);
+        assertEquals(member.getName(), changedMemberName);
+    }
+
+    @Test
+    @DisplayName("Delete")
+//    @Rollback(value = false)
+    public void deleteMember(){
+        // Given
+        Member member = MemberGenerator.createMember();
+
+        Member savedMember = this.memberCrudRepositorySpringDataJpa.save(member);
+        assertEquals(savedMember, member);
+
+        // When
+        this.memberCrudRepositorySpringDataJpa.delete(savedMember);
+
+        // Then
+        NoSuchElementException noSuchElementException = assertThrows(NoSuchElementException.class, () -> {
+            this.memberCrudRepositorySpringDataJpa.findById(member.getNo()).orElseThrow();
+        });
+        assertEquals(noSuchElementException.getMessage(), "No value present");
+    }
+
+    @Test
+    @DisplayName("Count")
+//    @Rollback(value = false)
+    public void memberCount(){
+        // Given
+        Member firstMember = MemberGenerator.createMemberByMemberName("최용석", 31);
+        Member secondMember = MemberGenerator.createMemberByMemberName("이성욱", 31);
+        Member thirdMember = MemberGenerator.createMemberByMemberName("박재현", 29);
+        this.memberCrudRepositorySpringDataJpa.save(firstMember);
+        this.memberCrudRepositorySpringDataJpa.save(secondMember);
+        this.memberCrudRepositorySpringDataJpa.save(thirdMember);
+
+        // When
+        long memberCount = this.memberCrudRepositorySpringDataJpa.count();
+
+        // Then
+        assertThat(memberCount).isNotZero();
+        assertEquals(memberCount, 3);
+    }
+
+    @Test
+    @DisplayName("FindAll")
+    public void findAllMember(){
+        // Given
+        Member firstMember = MemberGenerator.createMemberByMemberName("최용석", 31);
+        Member secondMember = MemberGenerator.createMemberByMemberName("이성욱", 31);
+        Member thirdMember = MemberGenerator.createMemberByMemberName("박재현", 29);
+        this.memberCrudRepositorySpringDataJpa.save(firstMember);
+        this.memberCrudRepositorySpringDataJpa.save(secondMember);
+        this.memberCrudRepositorySpringDataJpa.save(thirdMember);
+
+        // When
+        List<Member> savedMemberList =this.memberCrudRepositorySpringDataJpa.findAll(); // JPQL 실행 전 flush 발생
+
+        // Then
+        assertThat(savedMemberList.size()).isNotZero();
+        assertThat(savedMemberList.contains(firstMember));
+        assertThat(savedMemberList.contains(secondMember));
+        assertThat(savedMemberList.contains(thirdMember));
+        assertThat(savedMemberList.contains(thirdMember));
+    }
+}


### PR DESCRIPTION
 - JPA를 이용한 Member CRUD Repository 작성
   - Member Entity의 CRUD 구현
   - JPA로 작성된 Member CRUD Repository TC 작성
 - Spring Data JPA를 이용한 Member Repository 생성
   - Spring Data JPA로 작성된 Member CRUD Repository TC 작성

 - TC 구동 환경 설정
   - BaseTest : 각 TC에서 공통으로 선언되는 Annotation 설정
   - MemberGenerator : 회원 TC 수행에 필요한 Member Entity 생성