### PR TITLE
[2021-04-06]용석:연관관계를 가지는 Entity의 Join 연산을 통한 순수 JPA와 Spring Data JPA의 비교

### DIFF
--- a/src/main/java/io/example/springdatajpa/repository/ch03_team_member_join/TeamMemberJoinRepositoryJpa.java
+++ b/src/main/java/io/example/springdatajpa/repository/ch03_team_member_join/TeamMemberJoinRepositoryJpa.java
@@ -1,0 +1,97 @@
+package io.example.springdatajpa.repository.ch03_team_member_join;
+
+import io.example.springdatajpa.domain.entity.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+import java.util.List;
+
+/**
+ * @author : choi-ys
+ * @date : 2021/04/06 9:51 오전
+ * @Content : 순수 JPA를 이용한 회원과 팀의 연관관계 Join 연산
+ *  - 특정 팀에 소속된 회원 목록 조회
+ *  - 특정 팀의 특정 회원 조회
+ *  - 특정 회원의 정보와 해당 회원이 소속된 팀정보
+ */
+@Repository
+@RequiredArgsConstructor
+public class TeamMemberJoinRepositoryJpa {
+
+    private final EntityManager entityManager;
+
+    /** 특정 팀에 소속된 회원 목록 조회
+     *     select
+     *         member0_.member_no as member_n1_0_,
+     *         member0_.age as age2_0_,
+     *         member0_.member_name as member_n3_0_,
+     *         member0_.team_no as team_no4_0_
+     *     from
+     *         member_tb member0_
+     *     inner join
+     *         team_tb team1_
+     *             on member0_.team_no=team1_.team_no
+     *     where
+     *         team1_.team_no=1
+     * @param teamNo 팀 번호
+     * @return List<Member> 회원 목록
+     */
+    public List<Member> findMemberListByTeamNo(long teamNo){
+        return entityManager.createQuery("select m from Member as m" +
+                " join m.team as t" +
+                " where t.no = :teamNo", Member.class)
+                .setParameter("teamNo", teamNo)
+                .getResultList();
+    }
+
+    /** 특정 팀의 특정 회원 조회
+     *     select
+     *         member0_.member_no as member_n1_0_,
+     *         member0_.age as age2_0_,
+     *         member0_.member_name as member_n3_0_,
+     *         member0_.team_no as team_no4_0_
+     *     from
+     *         member_tb member0_
+     *     inner join
+     *         team_tb team1_
+     *             on member0_.team_no=team1_.team_no
+     *     where
+     *         member0_.member_no=1
+     * @param memberNo 회원 번호
+     * @return Member 회원정보
+     */
+    public Member findMemberByMemberNo(long memberNo){
+        return entityManager.createQuery("select m from Member as m" +
+                " join m.team as t" +
+                " where m.no = :memberNo", Member.class)
+                .setParameter("memberNo", memberNo)
+                .getSingleResult();
+    }
+
+    /** 특정 회원의 정보와 해당 회원이 소속된 팀정보
+     *     select
+     *         member0_.member_no as member_n1_0_0_,
+     *         team1_.team_no as team_no1_1_1_,
+     *         member0_.age as age2_0_0_,
+     *         member0_.member_name as member_n3_0_0_,
+     *         member0_.team_no as team_no4_0_0_,
+     *         team1_.team_name as team_nam2_1_1_
+     *     from
+     *         member_tb member0_
+     *     inner join
+     *         team_tb team1_
+     *             on member0_.team_no=team1_.team_no
+     *     where
+     *         member0_.member_no=1
+     * @param memberNo
+     * @return
+     */
+    public Member findMemberAndTeamByMemberNo(long memberNo){
+        return entityManager.createQuery("select m from Member as m" +
+                " join fetch m.team as t" +
+                " where m.no = :memberNo", Member.class)
+                .setParameter("memberNo", memberNo)
+                .getSingleResult();
+    }
+}

--- a/src/main/java/io/example/springdatajpa/repository/ch03_team_member_join/TeamMemberJoinRepositoryQueryAnnotation.java
+++ b/src/main/java/io/example/springdatajpa/repository/ch03_team_member_join/TeamMemberJoinRepositoryQueryAnnotation.java
@@ -1,0 +1,75 @@
+package io.example.springdatajpa.repository.ch03_team_member_join;
+
+import io.example.springdatajpa.domain.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+/**
+ * @author : choi-ys
+ * @date : 2021/04/06 1:58 오후
+ * @Content : Spring Data JPA의 Query Annotation를 이용한 회원과 팀의 연관관게 Join 연산
+ *  - 특정 팀에 소속된 회원 목록 조회
+ *  - 특정 팀의 특정 회원 조회
+ *  - 특정 회원의 정보와 해당 회원이 소속된 팀정보
+ */
+public interface TeamMemberJoinRepositoryQueryAnnotation extends JpaRepository<Member, Long> {
+
+    /** 특정 팀에 소속된 회원 목록 조회
+     *     select
+     *         member0_.member_no as member_n1_0_,
+     *         member0_.age as age2_0_,
+     *         member0_.member_name as member_n3_0_,
+     *         member0_.team_no as team_no4_0_
+     *     from
+     *         member_tb member0_
+     *     inner join
+     *         team_tb team1_
+     *             on member0_.team_no=team1_.team_no
+     *     where
+     *         team1_.team_no=1
+     * @param teamNo
+     * @return
+     */
+    @Query("select m from Member as m join m.team as t where t.no = :teamNo")
+    List<Member> findMemberListByTeamNo(@Param("teamNo") long teamNo);
+
+    /** 특정 팀의 특정 회원 조회
+     *     select
+     *         member0_.member_no as member_n1_0_,
+     *         member0_.age as age2_0_o
+     *         member0_.member_name as member_n3_0_,
+     *         member0_.team_no as team_no4_0_
+     *         member_tb member0_
+     *     inner join
+     *         team_tb team1_
+     *             on member0_.team_no=team1_.team_no
+     *     where
+     *         member0_.member_no=1
+     * @param memberNo
+     * @return
+     */
+    @Query("select m from Member as m join m.team as t where m.no = :memberNo")
+    Member findMemberByNo(@Param("memberNo") long memberNo);
+
+    /** 특정 회원의 정보와 해당 회원이 소속된 팀정보
+     *     select
+     *         member0_.member_no as member_n1_0_0_,
+     *         team1_.team_no as team_no1_1_1_,
+     *         member0_.age as age2_0_0_,
+     *         member0_.member_name as member_n3_0_0_,
+     *         member0_.team_no as team_no4_0_0_,
+     *         team1_.team_name as team_nam2_1_1_
+     *     from
+     *         member_tb member0_
+     *     inner join
+     *         team_tb team1_
+     *             on member0_.team_no=team1_.team_no
+     *     where
+     *         member0_.member_no=1
+     */
+    @Query("select m from Member as m join fetch m.team as t where m.no = :memberNo")
+    Member findMemberByMemberNo(@Param("memberNo") long memberNo);
+}

--- a/src/main/java/io/example/springdatajpa/repository/ch03_team_member_join/TeamMemberJoinRepositoryQueryMethod.java
+++ b/src/main/java/io/example/springdatajpa/repository/ch03_team_member_join/TeamMemberJoinRepositoryQueryMethod.java
@@ -1,0 +1,78 @@
+package io.example.springdatajpa.repository.ch03_team_member_join;
+
+import io.example.springdatajpa.domain.entity.Member;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+/**
+ * @author : choi-ys
+ * @date : 2021/04/06 11:44 오전
+ * @Content : Spring Data JPA의 Query Method를 이용한 회원과 팀의 연관관계 join 연산
+ *  - 특정 팀에 소속된 회원 목록 조회
+ *  - 특정 팀의 특정 회원 조회
+ *  - 특정 회원의 정보와 해당 회원이 소속된 팀정보
+ */
+public interface TeamMemberJoinRepositoryQueryMethod extends JpaRepository<Member, Long> {
+
+    /** 특정 팀에 소속된 회원 목록 조회
+     *     select
+     *         member0_.member_no as member_n1_0_,
+     *         member0_.age as age2_0_,
+     *         member0_.member_name as member_n3_0_,
+     *         member0_.team_no as team_no4_0_
+     *     from
+     *         member_tb member0_
+     *     left outer join
+     *         team_tb team1_
+     *             on member0_.team_no=team1_.team_no
+     *     where
+     *         team1_.team_no=1
+     * @param teamNo
+     * @return
+     */
+    List<Member> findMemberListByTeamNo(long teamNo);
+
+    /** 특정 팀의 특정 회원 조회
+     *     select
+     *         member0_.member_no as member_n1_0_,
+     *         member0_.age as age2_0_,
+     *         member0_.member_name as member_n3_0_,
+     *         member0_.team_no as team_no4_0_
+     *     from
+     *         member_tb member0_
+     *     left outer join
+     *         team_tb team1_
+     *             on member0_.team_no=team1_.team_no
+     *     where
+     *         member0_.member_no=1
+     *         and team1_.team_no=1
+     * @param memberNo
+     * @param teamNo
+     * @return
+     */
+    Member findMemberByNoAndTeamNo(long memberNo, long teamNo);
+
+    /** 특정 회원의 정보와 해당 회원이 소속된 팀 정보
+     *     select
+     *         member0_.member_no as member_n1_0_0_,
+     *         team1_.team_no as team_no1_1_1_,
+     *         member0_.age as age2_0_0_,
+     *         member0_.member_name as member_n3_0_0_,
+     *         member0_.team_no as team_no4_0_0_,
+     *         team1_.team_name as team_nam2_1_1_
+     *     from
+     *         member_tb member0_
+     *     left outer join
+     *         team_tb team1_
+     *             on member0_.team_no=team1_.team_no
+     *     where
+     *         member0_.member_no=1
+     * @param memberNo
+     * @return
+     */
+    @EntityGraph(attributePaths = "team")
+    Member findFetchMemberAndTeamByNo(long memberNo);
+
+}

--- a/src/test/java/io/example/springdatajpa/generator/MemberGenerator.java
+++ b/src/test/java/io/example/springdatajpa/generator/MemberGenerator.java
@@ -2,6 +2,8 @@ package io.example.springdatajpa.generator;
 
 import io.example.springdatajpa.domain.entity.Member;
 import io.example.springdatajpa.domain.entity.Team;
+import io.example.springdatajpa.repository.ch01_member_crud.MemberCrudRepositorySpringDataJpa;
+import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * @author : choi-ys
@@ -10,11 +12,27 @@ import io.example.springdatajpa.domain.entity.Team;
  */
 public class MemberGenerator {
 
+    @Autowired
+    MemberCrudRepositorySpringDataJpa memberCrudRepositorySpringDataJpa;
+
+    public Member savedMember(){
+        return memberCrudRepositorySpringDataJpa.save(createMember());
+    }
+
+    public Member savedMemberByParam(String memberName, int age){
+        return memberCrudRepositorySpringDataJpa.save(createMemberByParam(memberName, age));
+    }
+
+    public Member savedMemberWithTeam(String memberName, int age, Team team){
+        return memberCrudRepositorySpringDataJpa.save(
+                createMemberWithTeam(memberName, age, team)
+        );
+    }
+
     public static Member createMember(){
         String memberName = "최용석";
         int age = 31;
-        Team team = TeamGenerator.createTeam();
-        return memberBuilder(memberName, age, team);
+        return createMemberByParam(memberName, age);
     }
 
     public static Member createMemberByParam(String memberName, int age){

--- a/src/test/java/io/example/springdatajpa/generator/TeamGenerator.java
+++ b/src/test/java/io/example/springdatajpa/generator/TeamGenerator.java
@@ -1,6 +1,8 @@
 package io.example.springdatajpa.generator;
 
 import io.example.springdatajpa.domain.entity.Team;
+import io.example.springdatajpa.repository.ch02_team_crud.TeamCrudRepositorySpringDataJpa;
+import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * @author : choi-ys
@@ -8,6 +10,13 @@ import io.example.springdatajpa.domain.entity.Team;
  * @Content : 팀 TC 수행에 필요한 Team Entity 생성
  */
 public class TeamGenerator {
+
+    @Autowired
+    TeamCrudRepositorySpringDataJpa teamCrudRepositorySpringDataJpa;
+
+    public Team savedTeam(){
+        return teamCrudRepositorySpringDataJpa.save(createTeam());
+    }
 
     public static Team createTeam(){
         String teamName = "CoreDevTeam";

--- a/src/test/java/io/example/springdatajpa/repository/ch03_team_member_join/TeamMemberJoinRepositoryJpaTest.java
+++ b/src/test/java/io/example/springdatajpa/repository/ch03_team_member_join/TeamMemberJoinRepositoryJpaTest.java
@@ -1,0 +1,102 @@
+package io.example.springdatajpa.repository.ch03_team_member_join;
+
+import io.example.springdatajpa.common.BaseTest;
+import io.example.springdatajpa.domain.entity.Member;
+import io.example.springdatajpa.domain.entity.Team;
+import io.example.springdatajpa.generator.MemberGenerator;
+import io.example.springdatajpa.generator.TeamGenerator;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.Import;
+
+import javax.annotation.Resource;
+import javax.persistence.EntityManager;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+/**
+ * @author : choi-ys
+ * @date : 2021/04/06 9:11 오전
+ * @Content : 순수 JPA를 이용한 Team과 Member 연관관계의 Join 쿼리 Test
+ *  - 특정 팀에 소속된 회원 목록 조회
+ *  - 특정 팀의 특정 회원 조회
+ *  - 특정 회원의 정보와 해당 회원이 소속된 팀정보
+ */
+@DisplayName("JoinRepository[JPA]:TeamMember")
+@Import({TeamGenerator.class, MemberGenerator.class})
+public class TeamMemberJoinRepositoryJpaTest extends BaseTest {
+
+    @Resource
+    TeamGenerator teamGenerator;
+
+    @Resource
+    MemberGenerator memberGenerator;
+
+    @Resource
+    TeamMemberJoinRepositoryJpa teamMemberJoinRepositoryJpa;
+
+    @Resource
+    EntityManager entityManager;
+
+    private void clearUp() {
+        entityManager.flush();
+        entityManager.clear();
+    }
+
+    @Test
+    @DisplayName("특정 팀에 소속된 회원 목록 조회")
+    public void findMemberListByTeamNo(){
+        // Given
+        Team savedTeam = teamGenerator.savedTeam();
+
+        Member savedFirstMember = memberGenerator.savedMemberWithTeam("최용석", 31, savedTeam);
+        Member savedSecondMember = memberGenerator.savedMemberWithTeam("이성욱", 31, savedTeam);
+        Member savedThirdMember = memberGenerator.savedMemberWithTeam("박재현", 29, savedTeam);
+
+        // When
+        List<Member> selectedMemberList = teamMemberJoinRepositoryJpa.findMemberListByTeamNo(savedTeam.getNo());
+
+        // Then
+        assertEquals(selectedMemberList.size(), 3);
+        assertEquals(selectedMemberList.contains(savedFirstMember), true);
+        assertEquals(selectedMemberList.contains(savedSecondMember), true);
+        assertEquals(selectedMemberList.contains(savedThirdMember), true);
+    }
+
+    @Test
+    @DisplayName("특정 팀의 특정 회원 조회")
+    public void findMemberByMemberNo(){
+        // Given
+        Team savedTeam = teamGenerator.savedTeam();
+        Member savedMember = memberGenerator.savedMemberWithTeam("최용석", 31, savedTeam);
+
+        // When
+        clearUp();
+        Member selectedMember = teamMemberJoinRepositoryJpa.findMemberByMemberNo(savedMember.getNo());
+
+        // Then
+        assertEquals(selectedMember.getNo(), savedMember.getNo());
+        assertEquals(selectedMember.getClass(), savedMember.getClass());
+        assertEquals(selectedMember.getTeam().getNo(), savedTeam.getNo());
+        assertNotEquals(selectedMember.getTeam().getClass(), savedTeam.getClass());
+    }
+
+    @Test
+    @DisplayName("특정 회원의 정보와 해당 회원이 소속된 팀정보 조회")
+    public void findMemberAndTeamByMemberNo(){
+        // Given
+        Team savedTeam = teamGenerator.savedTeam();
+        Member savedMember = memberGenerator.savedMemberWithTeam("최용석", 31, savedTeam);
+
+        // When
+        clearUp();
+        Member selectedMember = teamMemberJoinRepositoryJpa.findMemberAndTeamByMemberNo(savedMember.getNo());
+
+        // Then
+        assertEquals(selectedMember.getNo(), savedMember.getNo());
+        assertEquals(selectedMember.getTeam().getNo(), savedTeam.getNo());
+        assertEquals(selectedMember.getTeam().getClass(), savedTeam.getClass());
+    }
+}

--- a/src/test/java/io/example/springdatajpa/repository/ch03_team_member_join/TeamMemberJoinRepositoryQueryAnnotationTest.java
+++ b/src/test/java/io/example/springdatajpa/repository/ch03_team_member_join/TeamMemberJoinRepositoryQueryAnnotationTest.java
@@ -1,0 +1,109 @@
+package io.example.springdatajpa.repository.ch03_team_member_join;
+
+import io.example.springdatajpa.common.BaseTest;
+import io.example.springdatajpa.domain.entity.Member;
+import io.example.springdatajpa.domain.entity.Team;
+import io.example.springdatajpa.generator.MemberGenerator;
+import io.example.springdatajpa.generator.TeamGenerator;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+
+import javax.annotation.Resource;
+import javax.persistence.EntityManager;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * @author : choi-ys
+ * @date : 2021/04/06 2:07 오후
+ * @Content : Spring Data JPA의 Query Annotation을 이용한 Team과 Member 연관관계의 Join 쿼리 Test
+ *  - 특정 팀에 소속된 회원 목록 조회
+ *  - 특정 팀의 특정 회원 조회
+ *  - 특정 회원의 정보와 해당 회원이 소속된 팀정보
+ */
+@DisplayName("JoinRepository[QueryAnnotation]:TeamMember")
+@Import({TeamGenerator.class, MemberGenerator.class})
+class TeamMemberJoinRepositoryQueryAnnotationTest extends BaseTest {
+
+    @Resource
+    TeamGenerator teamGenerator;
+
+    @Resource
+    MemberGenerator memberGenerator;
+
+    @Resource
+    TeamMemberJoinRepositoryQueryAnnotation teamMemberJoinRepositoryQueryAnnotation;
+
+    @Resource
+    EntityManager entityManager;
+
+    private void clearUp() {
+        entityManager.flush();
+        entityManager.clear();
+    }
+
+    @Test
+    @DisplayName("특정 팀에 소속된 회원 목록 조회")
+    public void findMemberListByTeamNo(){
+        // Given
+        Team savedTeam = teamGenerator.savedTeam();
+        Member savedFirstMember = memberGenerator.savedMemberWithTeam("최용석", 31, savedTeam);
+        Member savedSecondMember = memberGenerator.savedMemberWithTeam("이성욱", 31, savedTeam);
+        Member savedThirdMember = memberGenerator.savedMemberWithTeam("박재현", 29, savedTeam);
+
+        // When
+        List<Member> selectedMemberList = teamMemberJoinRepositoryQueryAnnotation.findMemberListByTeamNo(savedTeam.getNo());
+
+        // Then
+        assertEquals(selectedMemberList.size(), 3);
+        assertEquals(selectedMemberList.contains(savedFirstMember), true);
+        assertEquals(selectedMemberList.contains(savedSecondMember), true);
+        assertEquals(selectedMemberList.contains(savedThirdMember), true);
+    }
+
+    @Test
+    @DisplayName("특정 팀의 특정 회원 조회")
+    public void findMemberByNo(){
+        // Given
+        Team savedTeam = teamGenerator.savedTeam();
+        Member savedMember = memberGenerator.savedMemberWithTeam("최용석", 31, savedTeam);
+
+        // When
+        clearUp();
+        Member selectedMember = teamMemberJoinRepositoryQueryAnnotation.findMemberByNo(savedMember.getNo());
+
+        // Then
+        System.out.println("AFTER persist Context Clear : " + selectedMember.getTeam().getName());
+
+        /**
+         * Member Entity와 연관관계를 가진 Team Entity가 지연로딩을 설정되어 있어,
+         * teamMemberJoinRepositoryQueryAnnotation의 findMemberByNo결과 Member객체의 Team Entity에는
+         * Hibernate Proxy객체로 존재한다.
+         */
+        assertEquals(selectedMember.getNo(), savedMember.getNo());
+        assertEquals(selectedMember.getClass(), savedMember.getClass());
+        assertEquals(selectedMember.getTeam().getNo(), savedTeam.getNo());
+        assertNotEquals(selectedMember.getTeam().getClass(), savedTeam.getClass());
+    }
+
+    @Test
+    @DisplayName("특정 회원의 정보와 해당 회원이 소속된 팀정보")
+    public void findMemberByMemberNo(){
+        // Given
+        Team savedTeam = teamGenerator.savedTeam();
+        Member savedMember = memberGenerator.savedMemberWithTeam("최용석", 31, savedTeam);
+
+        // When
+        clearUp();
+        Member selectedMember = teamMemberJoinRepositoryQueryAnnotation.findMemberByMemberNo(savedMember.getNo());
+
+        // Then
+        assertEquals(selectedMember.getNo(), savedMember.getNo());
+        assertEquals(selectedMember.getTeam().getNo(), savedTeam.getNo());
+        assertEquals(selectedMember.getTeam().getClass(), savedTeam.getClass());
+    }
+}

--- a/src/test/java/io/example/springdatajpa/repository/ch03_team_member_join/TeamMemberJoinRepositoryQueryMethodTest.java
+++ b/src/test/java/io/example/springdatajpa/repository/ch03_team_member_join/TeamMemberJoinRepositoryQueryMethodTest.java
@@ -1,0 +1,97 @@
+package io.example.springdatajpa.repository.ch03_team_member_join;
+
+import io.example.springdatajpa.common.BaseTest;
+import io.example.springdatajpa.domain.entity.Member;
+import io.example.springdatajpa.domain.entity.Team;
+import io.example.springdatajpa.generator.MemberGenerator;
+import io.example.springdatajpa.generator.TeamGenerator;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.Import;
+
+import javax.annotation.Resource;
+import javax.persistence.EntityManager;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+/**
+ * @author : choi-ys
+ * @date : 2021/04/06 11:47 오전
+ * @Content : Spring Data Jpa를 이용한 Team과 Member 연관관계의 Join 쿼리 Test
+ */
+@DisplayName("JoinRepository[QueryMethod]:TeamMember")
+@Import({TeamGenerator.class, MemberGenerator.class})
+class TeamMemberJoinRepositoryQueryMethodTest extends BaseTest {
+
+    @Resource
+    TeamGenerator teamGenerator;
+
+    @Resource
+    MemberGenerator memberGenerator;
+
+    @Resource
+    TeamMemberJoinRepositoryQueryMethod teamMemberJoinRepositoryQueryMethod;
+
+    @Resource
+    EntityManager entityManager;
+
+    private void clearUp() {
+        entityManager.flush();
+        entityManager.clear();
+    }
+
+    @Test
+    @DisplayName("특정 팀에 소속된 회원 목록 조회")
+    public void findMemberListByTeamNo(){
+        // Given
+        Team savedTeam = teamGenerator.savedTeam();
+        Member savedFirstMember = memberGenerator.savedMemberWithTeam("최용석", 31, savedTeam);
+        Member savedSecondMember = memberGenerator.savedMemberWithTeam("이성욱", 31, savedTeam);
+        Member savedThirdMember = memberGenerator.savedMemberWithTeam("박재현", 29, savedTeam);
+
+        // Then
+        List<Member> teamMemberList = teamMemberJoinRepositoryQueryMethod.findMemberListByTeamNo(savedTeam.getNo());
+
+        assertEquals(teamMemberList.size(), 3);
+        assertEquals(teamMemberList.contains(savedFirstMember), true);
+        assertEquals(teamMemberList.contains(savedSecondMember), true);
+        assertEquals(teamMemberList.contains(savedThirdMember), true);
+    }
+
+    @Test
+    @DisplayName("특정 팀의 특정 회원 조회")
+    public void findMemberByMemberNo(){
+        // Given
+        Team savedTeam = teamGenerator.savedTeam();
+        Member savedMember = memberGenerator.savedMemberWithTeam("최용석", 31, savedTeam);
+
+        // When
+        clearUp();
+        Member selectedMember = teamMemberJoinRepositoryQueryMethod.findMemberByNoAndTeamNo(savedMember.getNo(), savedTeam.getNo());
+
+        // Then
+        assertEquals(selectedMember.getNo(), savedMember.getNo());
+        assertEquals(selectedMember.getClass(), savedMember.getClass());
+        assertEquals(selectedMember.getTeam().getNo(), savedTeam.getNo());
+        assertNotEquals(selectedMember.getTeam().getClass(), savedTeam.getClass());
+    }
+
+    @Test
+    @DisplayName("특정 회원의 정보와 해당 회원이 소속된 팀정보 조회")
+    public void findMemberAndTeamByMemberNo(){
+        // Given
+        Team savedTeam = teamGenerator.savedTeam();
+        Member savedMember = memberGenerator.savedMemberWithTeam("최용석", 31, savedTeam);
+
+        // When
+        Member selectedMember = teamMemberJoinRepositoryQueryMethod.findFetchMemberAndTeamByNo(savedMember.getNo());
+
+        // Then
+        clearUp();
+        assertEquals(selectedMember.getNo(), savedMember.getNo());
+        assertEquals(selectedMember.getTeam().getNo(), savedTeam.getNo());
+        assertEquals(selectedMember.getTeam().getClass(), savedTeam.getClass());
+    }
+}


### PR DESCRIPTION
 - MemberGenerator, TeamGenerator : Join 연산을 위한 Test Entity 생성 부 추가
 - 순수 JPA의 JPQL을 이용한 Join연산과 Spring Data Jpa의 Query Annotation과 Query Method를 이용한 Join연산 부 구현 및 TC 작성